### PR TITLE
Add event ignore block

### DIFF
--- a/main.go
+++ b/main.go
@@ -117,7 +117,14 @@ func (p playSoundOnJoin) Register(s *discordgo.Session) {
 			logger.Debug("user does not have a join sound configured")
 			return
 		}
-		//check if the user is just joining voice. This prevents mute/change channel/etc from triggering the sound
+
+		ignoreEvent := vs.Deaf || vs.Mute || vs.SelfDeaf || vs.SelfMute || vs.SelfStream || vs.SelfVideo || vs.Suppress
+		if ignoreEvent {
+			logger.Debug("ignoring irrelevant voice state update event")
+			return
+		}
+
+		//check if the user is just joining voice. This prevents change channel from triggering the sound
 		channelID := vs.ChannelID
 		if vs.BeforeUpdate != nil && channelID == vs.BeforeUpdate.ChannelID {
 			logger.Debug("user already in same channel")


### PR DESCRIPTION
return early if voice state update is due to a mute / deafen / stream related event

Attempt to fix https://github.com/WhiskeyJack96/hellothere/issues/18#issue-3664182345

I believe the issue stems from a cache invalidation, therefore the later check on `vs.BeforeUpdate != nil` is no longer true. This logic would match the bot's behavior if there was an issue with the sound playing which then could prevent the disconnect.
To circumvent this behavior, we check the `VoiceStateUpdate` fields for any events we don't care to respond to and return before the bot connects to the voice channel.

I have no idea how to test this so godspeed 🫨


Also I attempted to clean up some of the checks by extracting them to a helper function. Goal being to keep `playSoundOnJoin` concise.